### PR TITLE
chore: adding new fulfillment proxy as default for print invoice and package labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "cypress:open": "cypress open"
   },
   "dependencies": {
-    "@vtexlab/gatsby-theme-instore-core": "0.27.1",
+    "@vtexlab/gatsby-theme-instore-core": "0.27.0-beta.0",
     "gatsby": "^3.7.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Beta version with fulfillment new proxy to print invoices and package labels 