### PR TITLE
Bumps @vtexlab/gatsby-theme-instore-core to 0.29.6-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "scripts": {
     "develop": "gatsby develop",
     "start": "yarn develop",
-    "build": "NODE_OPTIONS='--max-old-space-size=4096' gatsby build",
-    "serve": "gatsby serve",
+    "build": "NODE_OPTIONS='--max-old-space-size=4096' gatsby build --prefix-paths",
+    "serve": "gatsby serve --prefix-paths",
     "docker:serve": "sed -i -e 's/\\$PORT/80/' public/nginx.conf && docker run --rm --name local_nginx -v \"$PWD/public/nginx.conf:/etc/nginx/nginx.conf\" -v \"$PWD/public:/etc/nginx/html\" -p 80:80 -it fholzer/nginx-brotli@sha256:ebaf3265a9e21dcd4ddfe44b22d6c4d8fdec563c9a0afd69097f286fd8a0eb00",
     "clean": "gatsby clean",
     "test": "yarn lint:prettier",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "cypress:open": "cypress open"
   },
   "dependencies": {
-    "@vtexlab/gatsby-theme-instore-core": "0.29.6-beta.1",
+    "@vtexlab/gatsby-theme-instore-core": "0.29.6-beta.2",
     "gatsby": "^3.7.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "cypress:open": "cypress open"
   },
   "dependencies": {
-    "@vtexlab/gatsby-theme-instore-core": "0.29.6-beta.2",
+    "@vtexlab/gatsby-theme-instore-core": "0.29.6-beta.3",
     "gatsby": "^3.7.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "cypress:open": "cypress open"
   },
   "dependencies": {
-    "@vtexlab/gatsby-theme-instore-core": "0.21.0",
+    "@vtexlab/gatsby-theme-instore-core": "0.29.6-beta.1",
     "gatsby": "^3.7.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3533,10 +3533,10 @@
   resolved "https://registry.yarnpkg.com/@vtex/tsconfig/-/tsconfig-0.5.6.tgz#c0eb4222a75d1b8a4fefb1d85bbd9349880ddbe5"
   integrity sha512-3pdtp0QiUjW3YqyA+2YPV3AsAJ68wHWELrg7JMlr7ULHNb4mUfmTBx31zbWG94K3OWp0KJFfF3ytQ+I68foqKA==
 
-"@vtexlab/checkout-instore@2.196.1":
-  version "2.196.1"
-  resolved "https://registry.yarnpkg.com/@vtexlab/checkout-instore/-/checkout-instore-2.196.1.tgz#6b5d3cb0771c8e1a7b57b7775b94bd784cf2c5e0"
-  integrity sha512-tp6iKcBK/CTQDHPtprLRv+19FvIDpqnNvTw7196hhy/79yXKaqY0PD8mFyOJJ1/gnru+o+FRd5Vq6rPHfnEZsw==
+"@vtexlab/checkout-instore@2.202.0":
+  version "2.202.0"
+  resolved "https://registry.yarnpkg.com/@vtexlab/checkout-instore/-/checkout-instore-2.202.0.tgz#d3cebcb533edb2a7fd1948d599359265e8d6bb96"
+  integrity sha512-+7d2hrIWGf1B0mP3DyS24lD7P8RQMP60jGJO3miAmDNdnpWIUMLTrTqtYgN7sl2VFOq/bD1GqeKQ1mkgaVFiKQ==
   dependencies:
     "@fullstory/browser" "^1.4.5"
     "@material-ui/core" "^3.1.2"
@@ -3550,6 +3550,7 @@
     "@vtex/axios-concurrent-retry" "^4.0.10"
     "@vtex/butik" "^1.3.6"
     "@vtex/delivery-packages" "2.18.0"
+    "@vtex/diagnostics-web" "^0.3.1"
     "@vtex/estimate-calculator" "^1.1.0"
     "@vtex/evidence-client-js" "^2.1.1"
     "@vtex/phone" "^4.8.3"
@@ -3558,11 +3559,13 @@
     "@vtex/styleguide" "^9.145.0"
     "@vtexlab/instore-profile" "2.9.6"
     "@vtexlab/product-ops-utils" "^0.1.0"
+    abortcontroller-polyfill "^1.7.5"
     asap "^2.0.5"
     axios "^0.18.0"
     base64-url "^2.2.0"
     classnames "^2.2.5"
     clean-css "^4.2.3"
+    cockatiel "2.0.2"
     connected-react-router "^6.9.1"
     dexie "^3.0.3"
     events "^1.1.1"
@@ -3628,18 +3631,18 @@
     whatwg-fetch "2.0.4"
     yup "^0.32.11"
 
-"@vtexlab/gatsby-plugin-instore-nginx@0.21.0":
-  version "0.21.0"
-  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-plugin-instore-nginx/-/gatsby-plugin-instore-nginx-0.21.0.tgz#70f14c7980aaba173db8ac4b1a4a8f82d7e40a49"
-  integrity sha512-i/0nbjuPw/Fvt7VgIHqgAnXVtGN7s1i0l+nrPQqn1Iicm+1IoMEYhrblvl0pmcMbO07qiQ/lmydugTXZQgX8eA==
+"@vtexlab/gatsby-plugin-instore-nginx@0.29.6-beta.1":
+  version "0.29.6-beta.1"
+  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-plugin-instore-nginx/-/gatsby-plugin-instore-nginx-0.29.6-beta.1.tgz#ff89c516a81ed4d1fd993560eac1426080bd9561"
+  integrity sha512-ghBXxyxxNrd2XkJY0PhoCW78zo3lVDF9qGBKlmhdsyZiOgATdkQZt8lzoBHFi9rX9/Fa9izHl2wY45ErZdwcsQ==
   dependencies:
     kebab-hash "^0.1.2"
     webpack-assets-manifest "^4.0.6"
 
-"@vtexlab/gatsby-theme-instore-core@0.21.0":
-  version "0.21.0"
-  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-theme-instore-core/-/gatsby-theme-instore-core-0.21.0.tgz#d01a4fa6f0425eae91277564928e031847eabd2c"
-  integrity sha512-O75fGVCd8c1eGCZ6dDpA24WZmLVySLwnrAyObbBNfewiR3C9iJQhLp1vMRAKdhX23iJmhavaNDhvKIEPhN8JpA==
+"@vtexlab/gatsby-theme-instore-core@0.29.6-beta.1":
+  version "0.29.6-beta.1"
+  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-theme-instore-core/-/gatsby-theme-instore-core-0.29.6-beta.1.tgz#39fd63f00f55b0463ab81021a3df659c457f0f88"
+  integrity sha512-+wF0FyVaHjXkBRw5nSCBOIAY7ybV7oeU+cWJoseNj1U+U3Bq44aBGnX7jYqFYMBiJUR61vNhg47gxbm7OrBxxg==
   dependencies:
     "@babel/core" "^7.17.8"
     "@babel/plugin-transform-typescript" "^7.13.0"
@@ -3654,8 +3657,8 @@
     "@vtex/gatsby-plugin-admin-ui" "^0.6.6"
     "@vtex/gatsby-plugin-graphql" "^0.277.2"
     "@vtex/phone" "^4.10.5"
-    "@vtexlab/checkout-instore" "2.196.1"
-    "@vtexlab/gatsby-plugin-instore-nginx" "0.21.0"
+    "@vtexlab/checkout-instore" "2.202.0"
+    "@vtexlab/gatsby-plugin-instore-nginx" "0.29.6-beta.1"
     abortcontroller-polyfill "^1.7.3"
     assert "^2.0.0"
     babel-plugin-relay "^10.1.3"
@@ -3939,6 +3942,11 @@ abortcontroller-polyfill@^1.7.3:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.3.tgz#1b5b487bd6436b5b764fd52a612509702c3144b5"
   integrity sha512-zetDJxd89y3X99Kvo4qFx8GKlt6GsvN3UcRZHwU6iFA/0KiOmhkTVhe8oRoTBiTVPZu09x3vCra47+w8Yz1+2Q==
+
+abortcontroller-polyfill@^1.7.5:
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.5.tgz#6738495f4e901fbb57b6c0611d0c75f76c485bed"
+  integrity sha512-JMJ5soJWP18htbbxJjG7bG6yuI6pRhgJ0scHHTfkUjf6wjP912xZWvM+A4sJK3gqd9E8fcPbDnOefbA9Th/FIQ==
 
 abs-svg-path@^0.1.1:
   version "0.1.1"
@@ -5675,6 +5683,11 @@ coa@^2.0.2:
     "@types/q" "^1.5.1"
     chalk "^2.4.1"
     q "^1.1.2"
+
+cockatiel@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/cockatiel/-/cockatiel-2.0.2.tgz#b8bc06df324dd1c769833c4d91478eb1d5519b4f"
+  integrity sha512-ehw7t3twohGiMTxARX0AcFiUxndXLhnIBWbnRnHtfde2jRywlPpPB/o3s9YSptXPj6tkOG0fzET4CUUx4GIpEg==
 
 cockatiel@3.0.0-anyengine.0:
   version "3.0.0-anyengine.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3631,18 +3631,18 @@
     whatwg-fetch "2.0.4"
     yup "^0.32.11"
 
-"@vtexlab/gatsby-plugin-instore-nginx@0.29.6-beta.1":
-  version "0.29.6-beta.1"
-  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-plugin-instore-nginx/-/gatsby-plugin-instore-nginx-0.29.6-beta.1.tgz#ff89c516a81ed4d1fd993560eac1426080bd9561"
-  integrity sha512-ghBXxyxxNrd2XkJY0PhoCW78zo3lVDF9qGBKlmhdsyZiOgATdkQZt8lzoBHFi9rX9/Fa9izHl2wY45ErZdwcsQ==
+"@vtexlab/gatsby-plugin-instore-nginx@0.29.6-beta.2":
+  version "0.29.6-beta.2"
+  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-plugin-instore-nginx/-/gatsby-plugin-instore-nginx-0.29.6-beta.2.tgz#71b516a859d285d61bf8126e1f266274b8564f11"
+  integrity sha512-xJtpHuxQ7XEtqM/Anrh4yQ212aJaAqqdL8daSAnfjKUKIQzt7aFXG7EnqIbbcqvre9DDe7AgLFhXTeItKXVRhw==
   dependencies:
     kebab-hash "^0.1.2"
     webpack-assets-manifest "^4.0.6"
 
-"@vtexlab/gatsby-theme-instore-core@0.29.6-beta.1":
-  version "0.29.6-beta.1"
-  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-theme-instore-core/-/gatsby-theme-instore-core-0.29.6-beta.1.tgz#39fd63f00f55b0463ab81021a3df659c457f0f88"
-  integrity sha512-+wF0FyVaHjXkBRw5nSCBOIAY7ybV7oeU+cWJoseNj1U+U3Bq44aBGnX7jYqFYMBiJUR61vNhg47gxbm7OrBxxg==
+"@vtexlab/gatsby-theme-instore-core@0.29.6-beta.2":
+  version "0.29.6-beta.2"
+  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-theme-instore-core/-/gatsby-theme-instore-core-0.29.6-beta.2.tgz#070f94c28a8b45edb067c8cebc98e76324b7ebe6"
+  integrity sha512-Y1Pmzrh4Zf3ljibMXswBBClRijTCDb6hwGJzRFTWbo1dftSfervCCJBHQjddnB6u07rhuMFTqmgtBNpuHqJdLA==
   dependencies:
     "@babel/core" "^7.17.8"
     "@babel/plugin-transform-typescript" "^7.13.0"
@@ -3658,7 +3658,7 @@
     "@vtex/gatsby-plugin-graphql" "^0.277.2"
     "@vtex/phone" "^4.10.5"
     "@vtexlab/checkout-instore" "2.202.0"
-    "@vtexlab/gatsby-plugin-instore-nginx" "0.29.6-beta.1"
+    "@vtexlab/gatsby-plugin-instore-nginx" "0.29.6-beta.2"
     abortcontroller-polyfill "^1.7.3"
     assert "^2.0.0"
     babel-plugin-relay "^10.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3631,18 +3631,18 @@
     whatwg-fetch "2.0.4"
     yup "^0.32.11"
 
-"@vtexlab/gatsby-plugin-instore-nginx@0.29.6-beta.2":
-  version "0.29.6-beta.2"
-  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-plugin-instore-nginx/-/gatsby-plugin-instore-nginx-0.29.6-beta.2.tgz#71b516a859d285d61bf8126e1f266274b8564f11"
-  integrity sha512-xJtpHuxQ7XEtqM/Anrh4yQ212aJaAqqdL8daSAnfjKUKIQzt7aFXG7EnqIbbcqvre9DDe7AgLFhXTeItKXVRhw==
+"@vtexlab/gatsby-plugin-instore-nginx@0.29.6-beta.3":
+  version "0.29.6-beta.3"
+  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-plugin-instore-nginx/-/gatsby-plugin-instore-nginx-0.29.6-beta.3.tgz#17a228efbe183f8081308e6590a9f57216ce2399"
+  integrity sha512-iDydOpCnApNtwpMvbRo+HVZAKbL2VzjDzV/ckQMGnF/J31QZh86EMdVodv1DFB9BIHCH75AQLQ5ttAYMY2BpAw==
   dependencies:
     kebab-hash "^0.1.2"
     webpack-assets-manifest "^4.0.6"
 
-"@vtexlab/gatsby-theme-instore-core@0.29.6-beta.2":
-  version "0.29.6-beta.2"
-  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-theme-instore-core/-/gatsby-theme-instore-core-0.29.6-beta.2.tgz#070f94c28a8b45edb067c8cebc98e76324b7ebe6"
-  integrity sha512-Y1Pmzrh4Zf3ljibMXswBBClRijTCDb6hwGJzRFTWbo1dftSfervCCJBHQjddnB6u07rhuMFTqmgtBNpuHqJdLA==
+"@vtexlab/gatsby-theme-instore-core@0.29.6-beta.3":
+  version "0.29.6-beta.3"
+  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-theme-instore-core/-/gatsby-theme-instore-core-0.29.6-beta.3.tgz#d6aaab6e7ec13b342aaa1c8907489b1a282b8505"
+  integrity sha512-/U+LUpXz43ccTG+j7yv3wugLvTSCPTMZz6Bt1h5Xzh1Om9yjBfEh3hqBle+QaskdjspXSiXbS5fRaytPduNvvw==
   dependencies:
     "@babel/core" "^7.17.8"
     "@babel/plugin-transform-typescript" "^7.13.0"
@@ -3658,7 +3658,7 @@
     "@vtex/gatsby-plugin-graphql" "^0.277.2"
     "@vtex/phone" "^4.10.5"
     "@vtexlab/checkout-instore" "2.202.0"
-    "@vtexlab/gatsby-plugin-instore-nginx" "0.29.6-beta.2"
+    "@vtexlab/gatsby-plugin-instore-nginx" "0.29.6-beta.3"
     abortcontroller-polyfill "^1.7.3"
     assert "^2.0.0"
     babel-plugin-relay "^10.1.3"


### PR DESCRIPTION
Updates @vtexlab/gatsby-theme-instore-core