### PR TITLE
Bumps @vtexlab/gatsby-theme-instore-core to 0.29.6-beta.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "scripts": {
     "develop": "gatsby develop",
     "start": "yarn develop",
-    "build": "NODE_OPTIONS='--max-old-space-size=4096' gatsby build",
-    "serve": "gatsby serve",
+    "build": "NODE_OPTIONS='--max-old-space-size=4096' gatsby build --prefix-paths",
+    "serve": "gatsby serve --prefix-paths",
     "docker:serve": "sed -i -e 's/\\$PORT/80/' public/nginx.conf && docker run --rm --name local_nginx -v \"$PWD/public/nginx.conf:/etc/nginx/nginx.conf\" -v \"$PWD/public:/etc/nginx/html\" -p 80:80 -it fholzer/nginx-brotli@sha256:ebaf3265a9e21dcd4ddfe44b22d6c4d8fdec563c9a0afd69097f286fd8a0eb00",
     "clean": "gatsby clean",
     "test": "yarn lint:prettier",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "cypress:open": "cypress open"
   },
   "dependencies": {
-    "@vtexlab/gatsby-theme-instore-core": "0.29.6-beta.6",
+    "@vtexlab/gatsby-theme-instore-core": "0.29.6-beta.7",
     "gatsby": "^3.7.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "cypress:open": "cypress open"
   },
   "dependencies": {
-    "@vtexlab/gatsby-theme-instore-core": "0.29.10",
+    "@vtexlab/gatsby-theme-instore-core": "0.29.6-beta.6",
     "gatsby": "^3.7.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3533,10 +3533,10 @@
   resolved "https://registry.yarnpkg.com/@vtex/tsconfig/-/tsconfig-0.5.6.tgz#c0eb4222a75d1b8a4fefb1d85bbd9349880ddbe5"
   integrity sha512-3pdtp0QiUjW3YqyA+2YPV3AsAJ68wHWELrg7JMlr7ULHNb4mUfmTBx31zbWG94K3OWp0KJFfF3ytQ+I68foqKA==
 
-"@vtexlab/checkout-instore@2.202.2":
-  version "2.202.2"
-  resolved "https://registry.yarnpkg.com/@vtexlab/checkout-instore/-/checkout-instore-2.202.2.tgz#1f313c7f090f15d53ba4f6ac87933863b928042b"
-  integrity sha512-LOKgUi5mFxzG4wH386njpda969KrLosCJhSY6R1AGjiHIX3r+bZYTxiCx2cTZ7eZmyg5uGWVCWwlLVtM0xvQdQ==
+"@vtexlab/checkout-instore@2.202.0":
+  version "2.202.0"
+  resolved "https://registry.yarnpkg.com/@vtexlab/checkout-instore/-/checkout-instore-2.202.0.tgz#d3cebcb533edb2a7fd1948d599359265e8d6bb96"
+  integrity sha512-+7d2hrIWGf1B0mP3DyS24lD7P8RQMP60jGJO3miAmDNdnpWIUMLTrTqtYgN7sl2VFOq/bD1GqeKQ1mkgaVFiKQ==
   dependencies:
     "@fullstory/browser" "^1.4.5"
     "@material-ui/core" "^3.1.2"
@@ -3631,18 +3631,18 @@
     whatwg-fetch "2.0.4"
     yup "^0.32.11"
 
-"@vtexlab/gatsby-plugin-instore-nginx@0.29.0":
-  version "0.29.0"
-  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-plugin-instore-nginx/-/gatsby-plugin-instore-nginx-0.29.0.tgz#b6a1e0e6e12722b84ce7abac078dddf4ffef3d8f"
-  integrity sha512-05yY8626ajlTPbMqRXZ523qNpZBmLK4pWdtAW+fliwCtHnr7P5OHZmbSXvLli1nuYImWrIfVOaM70BXMU+sRNA==
+"@vtexlab/gatsby-plugin-instore-nginx@0.29.6-beta.6":
+  version "0.29.6-beta.6"
+  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-plugin-instore-nginx/-/gatsby-plugin-instore-nginx-0.29.6-beta.6.tgz#d22240826a73a6483a4a9064435136f209542aa0"
+  integrity sha512-tuk1czckpFu25W6+tP75y0LAzGeswmANFoR0I2QLFCWApis11U+IFBC85xRBG+KKXwLdEGWgCNE9mop7MX5d7Q==
   dependencies:
     kebab-hash "^0.1.2"
     webpack-assets-manifest "^4.0.6"
 
-"@vtexlab/gatsby-theme-instore-core@0.29.10":
-  version "0.29.10"
-  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-theme-instore-core/-/gatsby-theme-instore-core-0.29.10.tgz#25ea8b2b9781a8139c48440c6b28ac89d5ae85d0"
-  integrity sha512-IsIy5xl9QVHoQwtY1GMSUYet5aPPbtROTo9WZ47HJ1dTgrK4v0Zg8jp+vJsDIhT2Ik2zTnVMFCLksSOBjGxwzg==
+"@vtexlab/gatsby-theme-instore-core@0.29.6-beta.6":
+  version "0.29.6-beta.6"
+  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-theme-instore-core/-/gatsby-theme-instore-core-0.29.6-beta.6.tgz#aee2e3a0405558801c1916c7871fab8a8d044d58"
+  integrity sha512-GiF2qHv/UiO+CFc5ly7CRoEMgukeekSPtGJahKcvvaT4Q51jbalzCM9OyODV7YAvPCIz8SouF1oZn962lmuzMg==
   dependencies:
     "@babel/core" "^7.17.8"
     "@babel/plugin-transform-typescript" "^7.13.0"
@@ -3657,8 +3657,8 @@
     "@vtex/gatsby-plugin-admin-ui" "^0.6.6"
     "@vtex/gatsby-plugin-graphql" "^0.277.2"
     "@vtex/phone" "^4.10.5"
-    "@vtexlab/checkout-instore" "2.202.2"
-    "@vtexlab/gatsby-plugin-instore-nginx" "0.29.0"
+    "@vtexlab/checkout-instore" "2.202.0"
+    "@vtexlab/gatsby-plugin-instore-nginx" "0.29.6-beta.6"
     abortcontroller-polyfill "^1.7.3"
     assert "^2.0.0"
     babel-plugin-relay "^10.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3631,18 +3631,18 @@
     whatwg-fetch "2.0.4"
     yup "^0.32.11"
 
-"@vtexlab/gatsby-plugin-instore-nginx@0.29.6-beta.6":
-  version "0.29.6-beta.6"
-  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-plugin-instore-nginx/-/gatsby-plugin-instore-nginx-0.29.6-beta.6.tgz#d22240826a73a6483a4a9064435136f209542aa0"
-  integrity sha512-tuk1czckpFu25W6+tP75y0LAzGeswmANFoR0I2QLFCWApis11U+IFBC85xRBG+KKXwLdEGWgCNE9mop7MX5d7Q==
+"@vtexlab/gatsby-plugin-instore-nginx@0.29.6-beta.7":
+  version "0.29.6-beta.7"
+  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-plugin-instore-nginx/-/gatsby-plugin-instore-nginx-0.29.6-beta.7.tgz#4444525fbe8d4e75c8874704ec367b03196840c3"
+  integrity sha512-3x+TylGt5JzvY+j7jKF1Cvt3XxpzZOi7PjhGalZPoM4mSjI3kqFYSsqugQVTdp+afWAlpjIiTV+v4WG2lOBpHg==
   dependencies:
     kebab-hash "^0.1.2"
     webpack-assets-manifest "^4.0.6"
 
-"@vtexlab/gatsby-theme-instore-core@0.29.6-beta.6":
-  version "0.29.6-beta.6"
-  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-theme-instore-core/-/gatsby-theme-instore-core-0.29.6-beta.6.tgz#aee2e3a0405558801c1916c7871fab8a8d044d58"
-  integrity sha512-GiF2qHv/UiO+CFc5ly7CRoEMgukeekSPtGJahKcvvaT4Q51jbalzCM9OyODV7YAvPCIz8SouF1oZn962lmuzMg==
+"@vtexlab/gatsby-theme-instore-core@0.29.6-beta.7":
+  version "0.29.6-beta.7"
+  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-theme-instore-core/-/gatsby-theme-instore-core-0.29.6-beta.7.tgz#88f3f61ea2972b2b28e8d60498aa78eded97557b"
+  integrity sha512-oBOdx9luzl4MdbJE1F1rAPf9U9Mi8ZwXVDum6reEurrsV6IhvkqYMbCl5hyDMENmxGrsVjDq4Ln/vvIB8pXKiw==
   dependencies:
     "@babel/core" "^7.17.8"
     "@babel/plugin-transform-typescript" "^7.13.0"
@@ -3658,7 +3658,7 @@
     "@vtex/gatsby-plugin-graphql" "^0.277.2"
     "@vtex/phone" "^4.10.5"
     "@vtexlab/checkout-instore" "2.202.0"
-    "@vtexlab/gatsby-plugin-instore-nginx" "0.29.6-beta.6"
+    "@vtexlab/gatsby-plugin-instore-nginx" "0.29.6-beta.7"
     abortcontroller-polyfill "^1.7.3"
     assert "^2.0.0"
     babel-plugin-relay "^10.1.3"


### PR DESCRIPTION
Updates @vtexlab/gatsby-theme-instore-core